### PR TITLE
Correct path of the scripts folder in Readme file

### DIFF
--- a/greengrass/README.md
+++ b/greengrass/README.md
@@ -10,7 +10,7 @@ for running AWS Greengrass.
 
 You can then switch to the greengrass sample script directory:
 
-	cd aws-iot-jitp-sample-script/greengrass
+	cd aws-iot-jitp-sample-scripts/greengrass
 	
 Then you will need to install the dependencies
 


### PR DESCRIPTION
*Issue #, if available:*
As part of the instructions to provision infrastructure for greengrass, we  need to "cd" to the scripts directory. But the name of the scripts directory is misspelled as "aws-iot-jitp-sample-script" in stead of "aws-iot-jitp-sample-scripts"
*Description of changes:*
Corrected the name of the directory

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
