### PR TITLE
fixed the flag so that you can view the endpoint for ATS

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Connect your device
 To connect your device to AWS IoT, you can first discover your ATS endpoint
 using the command:
 
-	aws iot describe-endpoint --type iot:Data-ATS
+	aws iot describe-endpoint --endpoint-type iot:Data-ATS
 
 This will return the URL for the AWS IoT endpoint using the above ATS root
 certificates.  Supplied in the repo are a bin/pub and a bin/sub which 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The `describe-endpoint` command does not work when copying out of the readme, because the flag is --endpoint-type, not --type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
